### PR TITLE
Resolves #34 - Set the cookie Path when setting the Cookie

### DIFF
--- a/src/runtime/manager.ts
+++ b/src/runtime/manager.ts
@@ -78,7 +78,7 @@ export function createViewportManager(options: ViewportOptions, state: Ref<strin
         const date = new Date()
         date.setTime(date.getTime() + COOKIE_EXPIRES_IN_DAYS)
 
-        document.cookie = `${options.cookieName}=${state.value}; SameSite=Strict; Secure; Expires=${date.toUTCString()}`
+        document.cookie = `${options.cookieName}=${state.value}; SameSite=Strict; Secure; Expires=${date.toUTCString()}; Path=/`
       }
     },
   })


### PR DESCRIPTION
Set the cookie Path when setting the Cookie to avoid multiple cookies being set for different paths.