### PR TITLE
Add isLessOrEquals function

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 ## Features
 
-- ⚡️&nbsp; Fast & Light with [MatchMedia API](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia) ⚡️
+- �️&nbsp; Fast & Light with [MatchMedia API](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia) ⚡️
 - 🕶&nbsp; Auto detects the device viewport from Cookie & User-Agent
-- 👌&nbsp; Zero configuration to start
+- �️&nbsp; Zero configuration to start
 - 👴️&nbsp; Supports IE9+
 
 > **Note**\
@@ -255,6 +255,16 @@ viewport.isGreaterOrEquals('desktop') // Result: false.
 
 viewport.isLessThan('desktopWide') // Result: true.
 viewport.isLessThan('mobile') // Result: false.
+```
+
+### `viewport.isLessOrEquals`
+- Type: Boolean
+
+```js
+// Example: viewport.breakpoint is "tablet".
+
+viewport.isLessOrEquals('tablet') // Result: true.
+viewport.isLessOrEquals('mobile') // Result: false.
 ```
 
 ### `viewport.match`

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -20,6 +20,9 @@
         <code>isLessThan</code> → <b>{{ $viewport.isLessThan(breakpoint) }}</b>
       </p>
       <p>
+        <code>isLessOrEquals</code> → <b>{{ $viewport.isLessOrEquals(breakpoint) }}</b>
+      </p>
+      <p>
         <code>isGreaterThan</code> → <b>{{ $viewport.isGreaterThan(breakpoint) }}</b>
       </p>
       <p>

--- a/src/runtime/manager.ts
+++ b/src/runtime/manager.ts
@@ -73,6 +73,7 @@ export function createViewportManager(options: ViewportOptions, state: Ref<strin
     isGreaterOrEquals,
 
     isLessThan,
+    isLessOrEquals,
 
     match,
     matches,
@@ -126,6 +127,14 @@ export function createViewportManager(options: ViewportOptions, state: Ref<strin
     }
 
     return breakpointIndex < currentIndex
+  }
+
+  /**
+   * Returns true, if searchBreakpoint is less or equals the current breakpoint.
+   * @param searchBreakpoint - Breakpoint to search.
+   */
+  function isLessOrEquals(searchBreakpoint: string) {
+    return isLessThan(searchBreakpoint) || match(searchBreakpoint)
   }
 
   /**


### PR DESCRIPTION
Fixes #72

Add `isLessOrEquals` function to the viewport manager.

* **src/runtime/manager.ts**
  - Add `isLessOrEquals` function to check if the current breakpoint is less than or equal to the specified breakpoint.
  - Export the new `isLessOrEquals` function.

* **playground/pages/index.vue**
  - Add example usage of `viewport.isLessOrEquals` function.

* **README.md**
  - Add documentation for the new `viewport.isLessOrEquals` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mvrlin/nuxt-viewport/issues/72?shareId=7e528b4e-681d-461d-b7cd-5817684d1cdc).