### PR TITLE
feat: add `isLessOrEquals` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,16 @@ viewport.isLessThan('desktopWide') // Result: true.
 viewport.isLessThan('mobile') // Result: false.
 ```
 
+### `viewport.isLessOrEquals`
+- Type: Boolean
+
+```js
+// Example: viewport.breakpoint is "tablet".
+
+viewport.isLessOrEquals('tablet') // Result: true.
+viewport.isLessOrEquals('mobile') // Result: false.
+```
+
 ### `viewport.match`
 - Type: Boolean
 

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -20,6 +20,9 @@
         <code>isLessThan</code> → <b>{{ $viewport.isLessThan(breakpoint) }}</b>
       </p>
       <p>
+        <code>isLessOrEquals</code> → <b>{{ $viewport.isLessOrEquals(breakpoint) }}</b>
+      </p>
+      <p>
         <code>isGreaterThan</code> → <b>{{ $viewport.isGreaterThan(breakpoint) }}</b>
       </p>
       <p>

--- a/src/runtime/manager.ts
+++ b/src/runtime/manager.ts
@@ -73,6 +73,7 @@ export function createViewportManager(options: ViewportOptions, state: Ref<strin
     isGreaterOrEquals,
 
     isLessThan,
+    isLessOrEquals,
 
     match,
     matches,
@@ -126,6 +127,14 @@ export function createViewportManager(options: ViewportOptions, state: Ref<strin
     }
 
     return breakpointIndex < currentIndex
+  }
+
+  /**
+   * Returns true, if searchBreakpoint is less or equals the current breakpoint.
+   * @param searchBreakpoint - Breakpoint to search.
+   */
+  function isLessOrEquals(searchBreakpoint: string) {
+    return isLessThan(searchBreakpoint) || match(searchBreakpoint)
   }
 
   /**


### PR DESCRIPTION
Fixes #72

Add `isLessOrEquals` function to the viewport manager.

* **src/runtime/manager.ts**
  - Add `isLessOrEquals` function to check if the current breakpoint is less than or equal to the specified breakpoint.
  - Export the new `isLessOrEquals` function.

* **playground/pages/index.vue**
  - Add example usage of `viewport.isLessOrEquals` function.

* **README.md**
  - Add documentation for the new `viewport.isLessOrEquals` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mvrlin/nuxt-viewport/issues/72?shareId=cffff2d5-350e-4f52-ba92-12277ca96737).