### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ CSS media feature.
   // ...
   viewport: {
     breakpoints: {
-      xs: 320,
+      xs: 0,
       sm: 640,
       md: 768,
       lg: 1024,
@@ -203,7 +203,7 @@ CSS media feature.
       tablet: 'md',
     },
 
-    fallbackBreakpoint: 'lg'
+    fallbackBreakpoint: 'xs'
   },
   // ...
 }


### PR DESCRIPTION
In Tailwind 3 and 4 there is no `xs` breakpoint with 320px width, rather everything below 640 is the considered to be the default. I therefor lowered `xs` width to 0. I was also considering to rename `xs` to `default`, what do you think?

I also updated `xs` to be the fallback as Tailwind is mobile first this should be the default/fallback.